### PR TITLE
Account filter cannot be set for `getAttributes()` in LDAP adapter

### DIFF
--- a/src/Adapter/Basic/Ldap.php
+++ b/src/Adapter/Basic/Ldap.php
@@ -249,7 +249,7 @@ class Ldap extends AbstractBasic
     public function getAttributes(IdentityInterface $identity): array
     {
         $search = array_column($this->map, 'attr');
-        $filter = htmlspecialchars_decode(sprintf($this->identity_attribute.'=%s)', $identity->getIdentifier()));
+        $filter = htmlspecialchars_decode(sprintf($this->account_filter, $identity->getIdentifier()));
 
         $this->logger->debug("fetch ldap object attributes with [$filter]", [
             'category' => get_class($this),


### PR DESCRIPTION
**Fixed**: Account filter cannot be set for `getAttributes()` in LDAP adapter, leading to non-usability for custom account filters.

Normally, a user should be able to set the property `account_filter` by instantiating class `Micro\Auth\Adapter\Basic\Ldap` using the optional parameter `$ldap_options` and setting its index `$ldap_options['account_filter']` to a given value.
The value is set, but never read during a `Micro\Auth\Adapter\Basic\Ldap::getAttributes()` call.
`Micro\Auth\Adapter\Basic\Ldap::plainAuth()` already reads the property as intended.